### PR TITLE
解决release模式下启动奔溃的问题(ValiantCat/XXShield issue #10)

### DIFF
--- a/XXShield/Classes/SmartKit/NSObject+Forward.m
+++ b/XXShield/Classes/SmartKit/NSObject+Forward.m
@@ -16,11 +16,11 @@ XXStaticHookClass(NSObject, ProtectFW, id, @selector(forwardingTargetForSelector
     if (app_info.dli_saddr == NULL) {
         dladdr((__bridge void *)[UIApplication.sharedApplication.delegate class], &app_info);
     }
-    struct dl_info self_info;
+    struct dl_info self_info = {0};
     dladdr((__bridge void *)[self class], &self_info);
     
     //    ignore system class
-    if (strcmp(app_info.dli_fname, self_info.dli_fname)) {
+    if (self_info.dli_fname == NULL || strcmp(app_info.dli_fname, self_info.dli_fname)) {
         return XXHookOrgin(aSelector);
     }
     


### PR DESCRIPTION
存在两个问题：
1.dladdr可能无法找到dl_info，将不会对dl_info进行修改。而dl_info并没有初始化
2.strcmp没有对入参进行合法性验证

经验证，在Debug模式下，未初始化的self_info.dli_fname指针非空，所以strcmp未报异常，而Release模式下，self_info.dli_fname为空的可能性极高，容易crash