### PR TITLE
修复在后台线程使用了UIApplication.sharedApplication.delegate的问题、KVOProxy线程安全问题

### DIFF
--- a/XXShield/Classes/SmartKit/NSObject+Forward.m
+++ b/XXShield/Classes/SmartKit/NSObject+Forward.m
@@ -11,18 +11,28 @@
 #import "XXRecord.h"
 #import "XXShieldSwizzling.h"
 
-extern int main(int argc, char * argv[]);
+static bool startsWith(const char *pre, const char *str) {
+    size_t lenpre = strlen(pre),
+    lenstr = strlen(str);
+    return lenstr < lenpre ? false : strncmp(pre, str, lenpre) == 0;
+}
+
 
 XXStaticHookClass(NSObject, ProtectFW, id, @selector(forwardingTargetForSelector:), (SEL)aSelector) {
-    static struct dl_info app_info;
-    if (app_info.dli_saddr == NULL) {
-        dladdr(main, &app_info);
-    }
+    static dispatch_once_t onceToken;
+    static char *app_bundle_path = NULL;
+    
+    dispatch_once(&onceToken, ^{
+        const char *path = [[[NSBundle mainBundle] bundlePath] UTF8String];
+        app_bundle_path = malloc(strlen(path) + 1);
+        strcpy(app_bundle_path, path);
+    });
+    
     struct dl_info self_info = {0};
     dladdr((__bridge void *)[self class], &self_info);
     
     //    ignore system class
-    if (self_info.dli_fname == NULL || strcmp(app_info.dli_fname, self_info.dli_fname)) {
+    if (self_info.dli_fname == NULL || !startsWith(app_bundle_path, self_info.dli_fname)) {
         return XXHookOrgin(aSelector);
     }
     

--- a/XXShield/Classes/SmartKit/NSObject+Forward.m
+++ b/XXShield/Classes/SmartKit/NSObject+Forward.m
@@ -11,10 +11,12 @@
 #import "XXRecord.h"
 #import "XXShieldSwizzling.h"
 
+extern int main(int argc, char * argv[]);
+
 XXStaticHookClass(NSObject, ProtectFW, id, @selector(forwardingTargetForSelector:), (SEL)aSelector) {
     static struct dl_info app_info;
     if (app_info.dli_saddr == NULL) {
-        dladdr((__bridge void *)[UIApplication.sharedApplication.delegate class], &app_info);
+        dladdr(main, &app_info);
     }
     struct dl_info self_info = {0};
     dladdr((__bridge void *)[self class], &self_info);


### PR DESCRIPTION
1.UIApplication.sharedApplication.delegate只允许在UI线程调用，使用main函数指针取代
2.多线程环境下，KVOProxy出现各种crash，主要原因是KVOProxy对象、_kvoInfoMap未做同步访问